### PR TITLE
Fixed time retrieval

### DIFF
--- a/data_api/client.py
+++ b/data_api/client.py
@@ -169,6 +169,10 @@ def _build_pandas_data_frame(data, **kwargs):
         data_frame.set_index(index_field, inplace=True)
         data_frame.sort_index(inplace=True)
 
+        # convert to datetime if possible
+        if index_field == 'globalDate':
+            data_frame.index = pandas.to_datetime(data_frame.index)
+
     return data_frame
 
 

--- a/data_api/client.py
+++ b/data_api/client.py
@@ -344,7 +344,10 @@ def get_data(channels, start=None, end= None, range_type="globalDate", delta_ran
                 fillmethod = 'backfill'
             # simple padding with fillna
             interp_data.fillna(method=fillmethod, inplace=True)
-        elif interpolation_method == 'linear' or interpolation_method == 'nearest':
+        elif interpolation_method == 'linear':
+            # linear interpolation based on time
+            interp_data.interpolate(method = 'time', inplace=True)
+        elif interpolation_method == 'nearest':
             interp_data.interpolate(method = interpolation_method, inplace=True)
         else:
             raise RuntimeError("%s is not a valid interpolation specification" % interpolation_method)

--- a/data_api/client.py
+++ b/data_api/client.py
@@ -108,6 +108,7 @@ def _set_time_range(start_date, end_date, delta_time, margin = 0.0):
     return {"startDate": datetime.isoformat(start), "endDate": datetime.isoformat(end) }
 
 def _get_t_series(start, end, fixed_time_interval,tzinfo):
+    import pandas
     t_series = pandas.date_range(start=start, end=end, freq=fixed_time_interval, tz=tzinfo)
     #t_series_str = [t.strftime('%Y-%m-%dT%H:%M:%S.%f%z')[:-2]+':00' for t in t_series]
     return t_series
@@ -335,6 +336,7 @@ def get_data(channels, start=None, end= None, range_type="globalDate", delta_ran
     data = mapping_function(data, index_field=index_field)
 
     if fixed_time:
+        import pandas
         # print('fixed time interpolation')
         if index_field != 'globalDate':
             raise RuntimeError("Fixed time interpolation only availabe for range_type = globalDate")

--- a/tests/data_api/test_fixed.py
+++ b/tests/data_api/test_fixed.py
@@ -5,9 +5,13 @@ import pandas as pd
 start='2018-12-10 00:00:00.000'
 end  ='2018-12-18 00:00:00.000'
 channels = ['ABK1:IST:2','MHC1:IST:2']
-
+startsec = 1544396409.142
+endsec   = 1545087549.139
 # standard method
 data = api.get_data(channels=channels, start=start, end=end, base_url='https://data-api.psi.ch/hipa')
+
+# fixed time 1 hour interval, with padding
+data1h = api.get_data(channels=channels, start=start, end=end, base_url='https://data-api.psi.ch/hipa', fixed_time=True, fixed_time_interval='1 H')
 
 # fixed time 1 day interval, with padding
 data10 = api.get_data(channels=channels, start=start, end=end, base_url='https://data-api.psi.ch/hipa', fixed_time=True, fixed_time_interval='1 D')
@@ -21,3 +25,8 @@ data10lin = api.get_data(channels=channels, start=start, end=end, base_url='http
 # same with nearest neighbour
 data10nn = api.get_data(channels=channels, start=start, end=end, base_url='https://data-api.psi.ch/hipa', fixed_time=True, fixed_time_interval='1 D', interpolation_method='nearest')
 
+# check with range_type = "globalSeconds"
+datasec = api.get_data(channels=channels, start=startsec, end=endsec, base_url='https://data-api.psi.ch/hipa', range_type="globalSeconds")
+
+# check with range_type = "globalSeconds"
+datasec1h = api.get_data(channels=channels, start=startsec, end=endsec, base_url='https://data-api.psi.ch/hipa', range_type="globalSeconds", fixed_time=True, fixed_time_interval='1 H')

--- a/tests/data_api/test_fixed.py
+++ b/tests/data_api/test_fixed.py
@@ -5,7 +5,19 @@ import pandas as pd
 start='2018-12-10 00:00:00.000'
 end  ='2018-12-18 00:00:00.000'
 channels = ['ABK1:IST:2','MHC1:IST:2']
-data = api.get_data(channels=channels, start=start, end=end, base_url='https://data-api.psi.ch/hipa') 
 
-data10 = api.get_data(channels=channels, start=start, end=end, base_url='https://data-api.psi.ch/hipa', fixed_time=True, fixed_time_interval='1 D') 
+# standard method
+data = api.get_data(channels=channels, start=start, end=end, base_url='https://data-api.psi.ch/hipa')
+
+# fixed time 1 day interval, with padding
+data10 = api.get_data(channels=channels, start=start, end=end, base_url='https://data-api.psi.ch/hipa', fixed_time=True, fixed_time_interval='1 D')
+
+# same with backpadding
+data10back = api.get_data(channels=channels, start=start, end=end, base_url='https://data-api.psi.ch/hipa', fixed_time=True, fixed_time_interval='1 D', interpolation_method='previous')
+
+# same with linear interpolation
+data10lin = api.get_data(channels=channels, start=start, end=end, base_url='https://data-api.psi.ch/hipa', fixed_time=True, fixed_time_interval='1 D', interpolation_method='linear')
+
+# same with nearest neighbour
+data10nn = api.get_data(channels=channels, start=start, end=end, base_url='https://data-api.psi.ch/hipa', fixed_time=True, fixed_time_interval='1 D', interpolation_method='nearest')
 

--- a/tests/data_api/test_fixed.py
+++ b/tests/data_api/test_fixed.py
@@ -1,0 +1,11 @@
+import data_api as api
+import datetime
+import pandas as pd
+
+start='2018-12-10 00:00:00.000'
+end  ='2018-12-18 00:00:00.000'
+channels = ['ABK1:IST:2','MHC1:IST:2']
+data = api.get_data(channels=channels, start=start, end=end, base_url='https://data-api.psi.ch/hipa') 
+
+data10 = api.get_data(channels=channels, start=start, end=end, base_url='https://data-api.psi.ch/hipa', fixed_time=True, fixed_time_interval='1 D') 
+


### PR DESCRIPTION
This pull request implements fixed time retrieval for `range_type = globalDate`.

3 additional arguments are added to `get_data`:

* param `fixed_time`: bool
        data is returned at fixed time intervals, set by 'fixed_time_interval' and interpolated with the 'interpolation_method'
* param `fixed_time_interval`: string
        fixed time interval. Only used in case fixed_time = True
        possible values are described in https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html
* param `interpolation_method`: string
        interpolation method. Possible options are last (default), previous, linear and nearest.

The pull request will not change any previous behaviour apart from one thing: for the linear interpolation method the index of the dataframe needs to be a `datetime`. The index is changed from a string to a datetime as follows:

```
        # convert to datetime if possible
        if index_field == 'globalDate':
            data_frame.index = pandas.to_datetime(data_frame.index)
```

I believe this index change is an improvement and will allow for more flexible time analysis.

A test file has been added to check the functionality. But this can be deleted.