### PR TITLE
Send Accept: application/octet-stream on request

### DIFF
--- a/data_api3/reader.py
+++ b/data_api3/reader.py
@@ -224,9 +224,13 @@ def request(query, url="http://localhost:8080/api/v1/query"):
 
     http = urllib3.PoolManager(cert_reqs='CERT_NONE')
     urllib3.disable_warnings()
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/octet-stream',
+    }
     response = http.request('POST', url,
                             body=encoded_data,
-                            headers={'Content-Type': 'application/json'},
+                            headers=headers,
                             preload_content=False)
 
     # Were hitting this issue here:


### PR DESCRIPTION
Send application/octet-stream header to reassure the service that the client requests the response in the binary data api 3 format.

We can use this in the future to support different formats on the same endpoint based on the Accept header.

(REST Content Negotiation)