### PR TITLE
The empty array is scalar

### DIFF
--- a/data_api3/reader.py
+++ b/data_api3/reader.py
@@ -194,7 +194,7 @@ def process_channel_header(msg):
 
     if compression == 0:
         # NOTE legacy compatibility: historically a shape [1] is treated as scalar
-        if shape is None or shape == [1]:
+        if shape is None or len(shape) == 0 or shape == [1]:
             extractor = lambda b: struct.unpack(dtype, b)[0]
         else:
             extractor = lambda b: numpy.reshape(numpy.frombuffer(b, dtype=dtype), shape)


### PR DESCRIPTION
A shape == [] is a scalar. We also treat absent shape key as scalar.

Note: There is still the legacy compatibility that treats a shape == [1] also as scalar, whereas it should be 1-dim array of length 1.