### PR TITLE
Support scalar and waveform in h5 writing

### DIFF
--- a/data_api3/h5.py
+++ b/data_api3/h5.py
@@ -206,13 +206,13 @@ class Serializer:
                     if compression == "gzip":
                         dataset_options["compression"] = compression_opts
 
-            reference = self.file.require_dataset(dataset_name, [1]+shape, dtype=dtype, maxshape=[None,]+shape, **dataset_options)
+            reference = self.file.require_dataset(dataset_name, [1024]+shape, dtype=dtype, maxshape=[None,]+shape, **dataset_options)
             self.datasets[dataset_name] = Dataset(dataset_name, reference)
 
         dataset = self.datasets[dataset_name]
         # Check if dataset has required size, if not extend it
-        if dataset.reference.shape[0] < dataset.count + 1:
-            dataset.reference.resize(dataset.count + 1000, axis=0)
+        if dataset.reference.shape[0] <= dataset.count:
+            dataset.reference.resize(dataset.count + 1024, axis=0)
 
         # TODO need to add an None check - i.e. for different frequencies
         if value is not None:

--- a/data_api3/h5.py
+++ b/data_api3/h5.py
@@ -247,10 +247,11 @@ class Serializer:
         if dataset.reference.shape[0] < dataset.count + 1:
             dataset.reference.resize(dataset.count + 1000, axis=0)
 
-        # TODO need to add an None check - i.e. for different frequencies
         if value is not None:
             x_shape = (dataset.count,) + (0,) * len(shape)
             dataset.reference.id.write_direct_chunk(x_shape, value)
+        else:
+            raise RuntimeError(f"unexpected value type {type(value)}")
 
         dataset.count += 1
 

--- a/data_api3/h5.py
+++ b/data_api3/h5.py
@@ -10,47 +10,6 @@ import bitshuffle.h5
 import data_api3.reader
 
 
-def resolve_struct_dtype(header_type: str, header_byte_order: str) -> str:
-
-    header_type = header_type.lower()
-
-    if header_type == "float64":  # default
-        dtype = 'd'
-    elif header_type == "uint8":
-        dtype = 'B'
-    elif header_type == "int8":
-        dtype = 'b'
-    elif header_type == "uint16":
-        dtype = 'H'
-    elif header_type == "int16":
-        dtype = 'h'
-    elif header_type == "uint32":
-        dtype = 'I'
-    elif header_type == "int32":
-        dtype = 'i'
-    elif header_type == "uint64":
-        dtype = 'Q'
-    elif header_type == "int64":
-        dtype = 'q'
-    elif header_type == "float32":
-        dtype = 'f'
-    elif header_type == "bool8":
-        dtype = '?'
-    elif header_type == "bool":
-        dtype = '?'
-    elif header_type == "character":
-        dtype = 'c'
-    else:
-        # Unsupported data types:
-        # STRING
-        dtype = None
-
-    if dtype is not None and header_byte_order == "BIG_ENDIAN":
-        dtype = ">" + dtype
-
-    return dtype
-
-
 class HDF5Reader:
     def __init__(self, filename: str):
         self.messages_read = 0
@@ -122,7 +81,7 @@ class HDF5Reader:
                     current_compression = res.compression
                     current_shape = res.shape
                     current_h5shape = res.shape[::-1]
-                    current_dtype = resolve_struct_dtype(current_channel_info["type"], current_channel_info["byteOrder"])
+                    current_dtype = data_api3.reader.resolve_struct_dtype(current_channel_info["type"], current_channel_info["byteOrder"])
 
             bytes_read = stream.read(4)
             length_check = struct.unpack('>i', bytes_read)[0]

--- a/data_api3/h5.py
+++ b/data_api3/h5.py
@@ -144,6 +144,8 @@ class Serializer:
 
 
     def append_dataset(self, dataset_name, value, dtype="f8", shape=[], compress=False):
+        if value is None:
+            raise RuntimeError("attempt to write None value")
         if dataset_name not in self.datasets:
             dataset_options = {}
             if compress:
@@ -163,11 +165,7 @@ class Serializer:
         # Check if dataset has required size, if not extend it
         if dataset.reference.shape[0] <= dataset.count:
             dataset.reference.resize(dataset.count + 1024, axis=0)
-
-        # TODO need to add an None check - i.e. for different frequencies
-        if value is not None:
-            dataset.reference[dataset.count] = value
-
+        dataset.reference[dataset.count] = value
         dataset.count += 1
 
 

--- a/data_api3/h5.py
+++ b/data_api3/h5.py
@@ -92,10 +92,10 @@ class HDF5Reader:
 
 
 class Dataset:
-    def __init__(self, name, reference, count=0):
+    def __init__(self, name, reference):
         self.name = name
-        self.count = count
         self.reference = reference
+        self.count = 0
 
 
 class Serializer:

--- a/data_api3/h5.py
+++ b/data_api3/h5.py
@@ -220,9 +220,10 @@ class Serializer:
 
         dataset.count += 1
 
+
     def append_dataset_chunkwrite(self, dataset_name, value, dtype="float32", shape=[1,], compression=None):
-        # print(dataset_name, dtype, shape, compress)
-        if compression is None or compression != "bitshuffle_lz4":
+        # We currently accept only bitshuffle lz4 for direct chunk write
+        if compression != "bitshuffle_lz4":
             raise RuntimeError(f"unsupported compression {compression}")
 
         # the first 8 bytes hold the uncompressed byte size

--- a/data_api3/h5.py
+++ b/data_api3/h5.py
@@ -235,7 +235,7 @@ class Serializer:
         # Create dataset if not existing
         if dataset_name not in self.datasets_chunkwrite:
 
-            reference = self.file.create_dataset(dataset_name, tuple([1000]+shape), maxshape=tuple([None]+shape),
+            reference = self.file.create_dataset(dataset_name, tuple([1024]+shape), maxshape=tuple([None]+shape),
                                                  compression=bitshuffle.h5.H5FILTER,
                                                  compression_opts=(block_size, bitshuffle.h5.H5_COMPRESS_LZ4),
                                                  chunks=tuple([1]+shape), dtype=dtype)
@@ -244,8 +244,8 @@ class Serializer:
 
         dataset = self.datasets_chunkwrite[dataset_name]
 
-        if dataset.reference.shape[0] < dataset.count + 1:
-            dataset.reference.resize(dataset.count + 1000, axis=0)
+        if dataset.reference.shape[0] <= dataset.count:
+            dataset.reference.resize(dataset.count + 1024, axis=0)
 
         if value is not None:
             x_shape = (dataset.count,) + (0,) * len(shape)


### PR DESCRIPTION
H5 writing was used so far on imagebuffer for 2d datasets.
Here we improve support for writing scalar and 1d channels.